### PR TITLE
BSP-112: Studio ID, Token management.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "./packages/*"
             ],
             "devDependencies": {
-                "@jwalab/minilab": "^0.0.14"
+                "@jwalab/minilab": "^0.0.15"
             },
             "engines": {
                 "node": ">=14",
@@ -2066,9 +2066,9 @@
             }
         },
         "node_modules/@jwalab/minilab": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@jwalab/minilab/-/minilab-0.0.14.tgz",
-            "integrity": "sha512-3WyeAu5mcdvBmasu0++a12T/oSTHQY2MmLD5yQNt+ayXKeJxoZv6lO0igepgoTHqnYwoPocyGnlLKBOME8pmzQ==",
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/@jwalab/minilab/-/minilab-0.0.15.tgz",
+            "integrity": "sha512-wLAE2G429QhJntI6SuINbk8cPrTWn2zHddrHVZAwS8pEqLa1Y65gLlQdi6xaPolD4JIM13KmXqtpBm+oKYo9TQ==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
@@ -6598,6 +6598,11 @@
                 "verror": "1.10.0"
             }
         },
+        "node_modules/jwt-decode": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+            "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+        },
         "node_modules/keyv": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -10275,6 +10280,7 @@
         "packages/common": {
             "version": "0.0.1",
             "dependencies": {
+                "jwt-decode": "^3.1.2",
                 "node-dependency-injection": "^2.7.1",
                 "winston": "^3.3.3"
             },
@@ -11818,9 +11824,9 @@
             }
         },
         "@jwalab/minilab": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@jwalab/minilab/-/minilab-0.0.14.tgz",
-            "integrity": "sha512-3WyeAu5mcdvBmasu0++a12T/oSTHQY2MmLD5yQNt+ayXKeJxoZv6lO0igepgoTHqnYwoPocyGnlLKBOME8pmzQ==",
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/@jwalab/minilab/-/minilab-0.0.15.tgz",
+            "integrity": "sha512-wLAE2G429QhJntI6SuINbk8cPrTWn2zHddrHVZAwS8pEqLa1Y65gLlQdi6xaPolD4JIM13KmXqtpBm+oKYo9TQ==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
@@ -13058,6 +13064,7 @@
                 "@typescript-eslint/parser": "^4.29.3",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.3.0",
+                "jwt-decode": "^3.1.2",
                 "node-dependency-injection": "^2.7.1",
                 "openapi-types": "^9.3.0",
                 "prettier": "^2.3.2",
@@ -15358,6 +15365,11 @@
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
             }
+        },
+        "jwt-decode": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+            "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "keyv": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "homepage": "https://github.com/jwa-lab/item-service#readme",
     "devDependencies": {
-        "@jwalab/minilab": "^0.0.14"
+        "@jwalab/minilab": "^0.0.15"
     },
     "workspaces": [
         "./packages/*"

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -5,8 +5,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "common",
       "version": "0.0.1",
       "dependencies": {
+        "jwt-decode": "^3.1.2",
         "node-dependency-injection": "^2.7.1",
         "winston": "^3.3.3"
       },
@@ -721,9 +723,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
       "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
-      "dependencies": {
-        "wcwidth": ">=1.0.1"
-      },
       "optionalDependencies": {
         "wcwidth": ">=1.0.1"
       }
@@ -1334,6 +1333,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -3155,6 +3159,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kuler": {
       "version": "2.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,6 +21,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "jwt-decode": "^3.1.2",
     "node-dependency-injection": "^2.7.1",
     "winston": "^3.3.3"
   },

--- a/packages/common/src/NatsRunner/NatsRunner.ts
+++ b/packages/common/src/NatsRunner/NatsRunner.ts
@@ -12,6 +12,7 @@ import { AirlockMessage, Message } from "./Messages";
 export * from "./Messages";
 export * from "./Handlers";
 export * from "./Plugin";
+export * from "../utils";
 
 export enum AIRLOCK_VERBS {
   "GET" = "GET",

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./tokenParser";

--- a/packages/common/src/utils/tokenParser.ts
+++ b/packages/common/src/utils/tokenParser.ts
@@ -1,0 +1,30 @@
+import jwtDecode from "jwt-decode";
+import { MsgHdrs } from "nats";
+
+interface AirlockJWT {
+    uid: string;
+    cid: string;
+    sub?: string;
+    studio?: boolean;
+}
+
+export function parseJwtToNats(jwt: string): MsgHdrs {
+    if (!jwt) {
+        throw new Error("INVALID_JWT");
+    }
+
+    const cleanJwt = jwt.replace(/Bearer /g, "");
+    const decoded = jwtDecode<AirlockJWT>(cleanJwt);
+    const parsedJwt = Object.create(null);
+
+    parsedJwt["studio_id"] = decoded?.cid || "";
+    parsedJwt["user_id"] = decoded?.uid || "";
+    parsedJwt["username"] = decoded?.sub || "";
+    parsedJwt["is_studio"] = String(decoded?.studio) === "true";
+
+    return parsedJwt;
+}
+
+export function isStudio(headers: Record<string, unknown>): boolean {
+    return headers.is_studio === true;
+}

--- a/packages/item-service/seeds/create_items_table.js
+++ b/packages/item-service/seeds/create_items_table.js
@@ -7,6 +7,7 @@ module.exports = {
             .dropTableIfExists("items")
             .createTable("items", function (table) {
                 table.increments("item_id");
+                table.string("studio_id").notNullable();
                 table.string("name", 100).notNullable();
                 table.integer("total_quantity").notNullable();
                 table.integer("available_quantity").notNullable();

--- a/packages/item-service/src/entities/item.ts
+++ b/packages/item-service/src/entities/item.ts
@@ -2,6 +2,7 @@ import Joi from "joi";
 
 export class Item {
     readonly item_id?: number;
+    readonly studio_id: string;
     readonly name: string;
     readonly available_quantity: number;
     readonly total_quantity: number;
@@ -10,6 +11,7 @@ export class Item {
 
     constructor({
         item_id,
+        studio_id,
         name,
         available_quantity,
         total_quantity,
@@ -17,6 +19,7 @@ export class Item {
         data
     }: { [K in keyof Item]: Item[K] }) {
         this.item_id = item_id;
+        this.studio_id = studio_id;
         this.name = name;
         this.available_quantity = available_quantity;
         this.total_quantity = total_quantity;
@@ -26,7 +29,6 @@ export class Item {
 }
 
 export const itemSchema = Joi.object({
-    item_id: Joi.number().min(1),
     name: Joi.string().max(100).required(),
     available_quantity: Joi.number().min(0).required(),
     total_quantity: Joi.number().min(0).required(),

--- a/packages/item-service/src/natsHandlers/getItem/GetItem.ts
+++ b/packages/item-service/src/natsHandlers/getItem/GetItem.ts
@@ -1,16 +1,23 @@
 import { JSONCodec, NatsConnection, SubscriptionOptions } from "nats";
 
 import {
-    AirlockHandler,
-    PrivateHandler,
     AIRLOCK_VERBS,
+    AirlockHandler,
     AirlockMessage,
+    Logger,
     Message,
-    Logger
+    PrivateHandler,
+    isStudio
 } from "common";
 
 import { Item } from "../../entities/item";
 import { ItemRepository } from "../../repositories/ItemRepository";
+
+interface GetItemPayloadInterface {
+    item_id: number;
+    is_studio: boolean;
+    studio_id: string;
+}
 
 export class GetItemAirlockHandler extends AirlockHandler {
     readonly subject = "item.*";
@@ -31,13 +38,21 @@ export class GetItemAirlockHandler extends AirlockHandler {
     }
 
     async handle(msg: AirlockMessage): Promise<Item> {
+        if (!isStudio(msg.headers)) {
+            throw new Error("Invalid token type, a studio token is required.");
+        }
+
         const item_id = Number(msg.subject.split(".")[2]);
 
         this.logger.info(`Getting item ${item_id}`);
 
         const response = await this.natsConnection.request(
             "item-service.get-item",
-            JSONCodec().encode(item_id)
+            JSONCodec().encode({
+                item_id,
+                is_studio: msg.headers.is_studio,
+                studio_id: msg.headers.studio_id
+            })
         );
 
         return JSONCodec<Item>().decode(response.data);
@@ -60,7 +75,18 @@ export class GetItemHandler extends PrivateHandler {
         super();
     }
 
-    handle(msg: Message): Promise<Item> {
-        return this.itemRepository.getItem(msg.data as number);
+    async handle(msg: Message): Promise<Item> {
+        const data = msg.data as GetItemPayloadInterface;
+        const fetchedItem = await this.itemRepository.getItem(data.item_id);
+
+        if (!data?.is_studio) {
+            throw new Error("INVALID_JWT_STUDIO");
+        } else {
+            if (fetchedItem.studio_id !== data.studio_id) {
+                throw new Error("INVALID_STUDIO_ID");
+            }
+        }
+
+        return fetchedItem;
     }
 }

--- a/packages/item-service/tests/createItemAirlock.test.ts
+++ b/packages/item-service/tests/createItemAirlock.test.ts
@@ -5,6 +5,10 @@ import logger from "./utils/mockLogger";
 describe("Given CreateItem Airlock Handler", () => {
     let createItemAirlockHandler;
     let natsConnection;
+    const DEFAULT_STUDIO_HEADERS = {
+        studio_id: "studio_id",
+        is_studio: true
+    };
 
     beforeEach(() => {
         natsConnection = {
@@ -18,6 +22,28 @@ describe("Given CreateItem Airlock Handler", () => {
         );
     });
 
+    describe("When called with an invalid token type", () => {
+        it("Then throws an error indicating a bad token", () => {
+            expect(
+                createItemAirlockHandler.handle({
+                    body: {
+                        name: "test",
+                        total_quantity: 10,
+                        available_quantity: 10,
+                        data: {},
+                        frozen: false
+                    },
+                    headers: {
+                        studio_id: "studio_id",
+                        is_studio: false
+                    }
+                })
+            ).rejects.toThrow(
+                "Invalid token type, a studio token is required."
+            );
+        });
+    });
+
     describe("When called with an invalid message body", () => {
         it("Then throws an error when name is missing", () => {
             expect(
@@ -27,7 +53,8 @@ describe("Given CreateItem Airlock Handler", () => {
                         available_quantity: 10,
                         data: {},
                         frozen: false
-                    }
+                    },
+                    headers: DEFAULT_STUDIO_HEADERS
                 })
             ).rejects.toThrow('"name" is required');
         });
@@ -40,7 +67,8 @@ describe("Given CreateItem Airlock Handler", () => {
                         total_quantity: 10,
                         data: {},
                         frozen: false
-                    }
+                    },
+                    headers: DEFAULT_STUDIO_HEADERS
                 })
             ).rejects.toThrow(
                 '"name" length must be less than or equal to 100 characters long'
@@ -55,7 +83,8 @@ describe("Given CreateItem Airlock Handler", () => {
                         total_quantity: 10,
                         data: {},
                         frozen: false
-                    }
+                    },
+                    headers: DEFAULT_STUDIO_HEADERS
                 })
             ).rejects.toThrow('"available_quantity" is required');
         });
@@ -69,7 +98,8 @@ describe("Given CreateItem Airlock Handler", () => {
                         available_quantity: -1,
                         data: {},
                         frozen: false
-                    }
+                    },
+                    headers: DEFAULT_STUDIO_HEADERS
                 })
             ).rejects.toThrow(
                 '"available_quantity" must be greater than or equal to 0'
@@ -87,7 +117,8 @@ describe("Given CreateItem Airlock Handler", () => {
                             test: true
                         },
                         frozen: false
-                    }
+                    },
+                    headers: DEFAULT_STUDIO_HEADERS
                 })
             ).rejects.toThrow('"data.test" must be a string');
         });
@@ -112,7 +143,8 @@ describe("Given CreateItem Airlock Handler", () => {
                     available_quantity: 10,
                     data: {},
                     frozen: false
-                }
+                },
+                headers: DEFAULT_STUDIO_HEADERS
             });
         });
 

--- a/packages/item-service/tests/createItemPrivate.test.ts
+++ b/packages/item-service/tests/createItemPrivate.test.ts
@@ -54,7 +54,9 @@ describe("Given CreateItem  Handler", () => {
         });
 
         it("Then publishes a new ItemCreatedEvent event", () => {
-            expect(eventBus.publish.mock.calls[0][0]).toEqual(new ItemCreatedEvent(1));
+            expect(eventBus.publish.mock.calls[0][0]).toEqual(
+                new ItemCreatedEvent(1)
+            );
         });
     });
 });

--- a/packages/item-service/tests/getItemPrivate.test.ts
+++ b/packages/item-service/tests/getItemPrivate.test.ts
@@ -1,0 +1,62 @@
+import { GetItemHandler } from "../src/natsHandlers/getItem/GetItem";
+
+describe("Given GetItem Handler", () => {
+    let getItemHandler;
+    let itemRepository;
+
+    beforeEach(() => {
+        itemRepository = {
+            getItem: jest.fn().mockReturnValue({
+                item_id: 1,
+                studio_id: "studio_id",
+                name: "laboris ut eu",
+                available_quantity: 10,
+                total_quantity: 10,
+                is_frozen: false,
+                data: {}
+            })
+        };
+
+        getItemHandler = new GetItemHandler("test-service", itemRepository);
+    });
+
+    describe("When called with an item id by an invalid studio", () => {
+        it("Then throws an error about the given token.", () => {
+            expect(
+                getItemHandler.handle({
+                    data: {
+                        item_id: 1,
+                        studio_id: "studio_id_2",
+                        is_studio: true
+                    }
+                })
+            ).rejects.toThrow("INVALID_STUDIO_ID");
+        });
+    });
+
+    describe("When called with an item id", () => {
+        let response;
+
+        beforeEach(async () => {
+            response = await getItemHandler.handle({
+                data: {
+                    item_id: 1,
+                    studio_id: "studio_id",
+                    is_studio: true
+                }
+            });
+        });
+
+        it("Then returns the data of the requested item", () => {
+            expect(response).toEqual({
+                item_id: 1,
+                studio_id: "studio_id",
+                name: "laboris ut eu",
+                available_quantity: 10,
+                total_quantity: 10,
+                is_frozen: false,
+                data: {}
+            });
+        });
+    });
+});


### PR DESCRIPTION
BSP-112: Studio ID, Token management.
---
- feat(common/src/utils/tokenParser.ts): Parsing utils for airlock jwt.
- feat(item-service/tests/getItemPrivate.test.ts): Tests for the GetItem private handler.
---
- fix(package.json): Minilab version bump to 0.15.
- fix(common/package.json): jwt-decode added.
- fix(common/src/NatsRunner/Messages.ts): natsHeadersToObject function updated.
- fix(common/src/NatsRunner/NatsRunner.ts): utils index export.
- fix(item-service/seeds/create_items_table.js): studio_id added.
- fix(item-service/src/entities/item.ts): studio_id added.
- fix(item-service/src/natsHandlers/createItem/CreateItem.ts): Token management added.
- fix(item-service/src/natsHandlers/getItem/GetItem.ts): Token management added.
- fix(openapi-docs.json): Mandatory studio_id added.
- fix(item-service/tests/createItemAirlock.test.ts): ids added.